### PR TITLE
typo "kintone-ui-components" of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ create-react-app my-customization
 * Install kintone-ui-component from npm.
 ```
 $ cd my-customization
-$ npm install kintone-ui-components --dev
+$ npm install kintone-ui-component --dev
 ```
 * If you don't want to install kintone-ui-component from npm, you can follow below steps to install it.
 ```


### PR DESCRIPTION
your NPM package name is "kintone-ui-component", not "kintone-ui-components".

but ..
I think that all of them includes 'package name' should all be "components" as plural.
